### PR TITLE
fix reusing other ssh2 instances

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,7 @@ class SSH2Promise extends EventEmitter {
         options = Array.isArray(options) ? options : [options];
         this.config = options.map((o: any) => {
             o = Object.assign({}, defaultOptions, o);
-            o.uniqueId = o.uniqueId || `${o.username}@${o.host}`;
+	    o.uniqueId = o.uniqueId || `${o.username}@${o.host}:${o.port}`;
             return o;
         });
         this.deregister = [];


### PR DESCRIPTION
When connecting to a single host on different ports,
other sessions gets used than defined in the constructor.
This happens due identifying instances with "user@host".

A workaround can be overwriting the uniqueId field in the
constructors arguments with a custom value.

But as that is not documented, and it took a while to find the bug
in my application, i find this to be the more general solution to the issue.