### PR TITLE
Use `read` instead of `readData` and `write` instead of `writeData`.

### DIFF
--- a/dist/BaseSFTP.d.ts
+++ b/dist/BaseSFTP.d.ts
@@ -52,7 +52,7 @@ export default abstract class BaseSFTP extends EventEmitter {
      *
      * Returns `Promise<Array<any>>`
      */
-    readData(handle: Buffer, buffer: Buffer, offset: number, length: number, position: number): Promise<Array<any>>;
+    read(handle: Buffer, buffer: Buffer, offset: number, length: number, position: number): Promise<Array<any>>;
     /**
      * (Client-only)
      * Reads length bytes from the resource associated with file starting at position and stores the bytes in buffer starting at
@@ -75,7 +75,7 @@ export default abstract class BaseSFTP extends EventEmitter {
     *
     * Returns `Promise<void>`
     */
-    writeData(handle: Buffer, buffer: Buffer, offset: number, length: number, position: number): Promise<void>;
+    write(handle: Buffer, buffer: Buffer, offset: number, length: number, position: number): Promise<void>;
     /**
     * (Client-only)
     * Writes length bytes from buffer starting at offset to the resource associated with file starting at position.

--- a/dist/BaseSFTP.js
+++ b/dist/BaseSFTP.js
@@ -45,7 +45,7 @@ class BaseSFTP extends events_1.EventEmitter {
      *
      * Returns `Promise<Array<any>>`
      */
-    readData(handle, buffer, offset, length, position) {
+    read(handle, buffer, offset, length, position) {
         return Promise.reject(false);
     }
     /**
@@ -74,7 +74,7 @@ class BaseSFTP extends events_1.EventEmitter {
     *
     * Returns `Promise<void>`
     */
-    writeData(handle, buffer, offset, length, position) {
+    write(handle, buffer, offset, length, position) {
         return Promise.reject(false);
     }
     /**

--- a/dist/sftp.js
+++ b/dist/sftp.js
@@ -3,8 +3,8 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const sshConstants_1 = require("./sshConstants");
 const BaseSFTP_1 = require("./BaseSFTP");
 var stringFlagMap = ['r', 'r+', 'w', 'wx', 'xw', 'w+', 'wx+', 'xw+', 'a', 'ax', 'xa', 'a+', 'ax+', 'xa+'];
-var methods = ["fastGet", "fastPut", "open", "close", "readFile", "writeFile", "readData", "writeData", "fstat", "fsetstat", "futimes", "fchown", "fchmod", "opendir", "readdir", "unlink", "rename", "mkdir", "rmdir", "stat", "lstat", "setstat", "utimes", "chown", "chmod", "readlink", "symlink", "realpath", "ext_openssh_rename", "ext_openssh_statvfs", "ext_openssh_fstatvfs", "ext_openssh_hardlink", "ext_openssh_fsync"];
-var enhanceMethods = { "readFileData": "readData", "writeFileData": "writeData", "getStat": "fstat", "setStat": "fsetstat", "changeTimestamp": "futimes", "changeOwner": "fchown", "changeMode": "fchmod" };
+var methods = ["fastGet", "fastPut", "open", "close", "readFile", "writeFile", "read", "write", "fstat", "fsetstat", "futimes", "fchown", "fchmod", "opendir", "readdir", "unlink", "rename", "mkdir", "rmdir", "stat", "lstat", "setstat", "utimes", "chown", "chmod", "readlink", "symlink", "realpath", "ext_openssh_rename", "ext_openssh_statvfs", "ext_openssh_fstatvfs", "ext_openssh_hardlink", "ext_openssh_fsync"];
+var enhanceMethods = { "readFileData": "read", "writeFileData": "write", "getStat": "fstat", "setStat": "fsetstat", "changeTimestamp": "futimes", "changeOwner": "fchown", "changeMode": "fchmod" };
 class SFTP extends BaseSFTP_1.default {
     constructor(ssh) {
         super();

--- a/dist/sshUtils.d.ts
+++ b/dist/sshUtils.d.ts
@@ -1,7 +1,20 @@
 declare const _default: {
+    /**
+     * Peek the array
+     */
     peek: (arr: any[]) => any;
+    /**
+     * End pty socket session by sending kill signal
+     * @param {*} socket
+     */
     endSocket: (socket: any) => void;
+    /**
+     * Prompt for asking anything
+     */
     prompt: (question: string, cb: Function) => void;
+    /**
+     * Create a Deferred promise
+     */
     createDeferredPromise: () => {
         promise: Promise<{}>;
         resolve: undefined;

--- a/src/BaseSFTP.ts
+++ b/src/BaseSFTP.ts
@@ -66,7 +66,7 @@ export default abstract class BaseSFTP extends EventEmitter {
      *
      * Returns `Promise<Array<any>>`
      */
-    readData(handle: Buffer, buffer: Buffer, offset: number, length: number, position: number): Promise<Array<any>> {
+    read(handle: Buffer, buffer: Buffer, offset: number, length: number, position: number): Promise<Array<any>> {
         return Promise.reject(false);
     }
 
@@ -98,7 +98,7 @@ export default abstract class BaseSFTP extends EventEmitter {
     * 
     * Returns `Promise<void>`
     */
-    writeData(handle: Buffer, buffer: Buffer, offset: number, length: number, position: number): Promise<void> {
+    write(handle: Buffer, buffer: Buffer, offset: number, length: number, position: number): Promise<void> {
         return Promise.reject(false);
     }
 

--- a/src/sftp.ts
+++ b/src/sftp.ts
@@ -5,9 +5,9 @@ import { ReadStreamOptions, WriteStreamOptions } from 'ssh2-streams';
 
 var stringFlagMap = ['r', 'r+', 'w', 'wx', 'xw', 'w+', 'wx+', 'xw+', 'a', 'ax', 'xa', 'a+', 'ax+', 'xa+'];
 
-var methods = ["fastGet", "fastPut", "open", "close", "readFile", "writeFile", "readData", "writeData", "fstat", "fsetstat", "futimes", "fchown", "fchmod", "opendir", "readdir", "unlink", "rename", "mkdir", "rmdir", "stat", "lstat", "setstat", "utimes", "chown", "chmod", "readlink", "symlink", "realpath", "ext_openssh_rename", "ext_openssh_statvfs", "ext_openssh_fstatvfs", "ext_openssh_hardlink", "ext_openssh_fsync"];
+var methods = ["fastGet", "fastPut", "open", "close", "readFile", "writeFile", "read", "write", "fstat", "fsetstat", "futimes", "fchown", "fchmod", "opendir", "readdir", "unlink", "rename", "mkdir", "rmdir", "stat", "lstat", "setstat", "utimes", "chown", "chmod", "readlink", "symlink", "realpath", "ext_openssh_rename", "ext_openssh_statvfs", "ext_openssh_fstatvfs", "ext_openssh_hardlink", "ext_openssh_fsync"];
 
-var enhanceMethods: any = {"readFileData": "readData", "writeFileData": "writeData", "getStat": "fstat", "setStat": "fsetstat", "changeTimestamp": "futimes", "changeOwner": "fchown", "changeMode": "fchmod"};
+var enhanceMethods: any = {"readFileData": "read", "writeFileData": "write", "getStat": "fstat", "setStat": "fsetstat", "changeTimestamp": "futimes", "changeOwner": "fchown", "changeMode": "fchmod"};
 
 export default class SFTP extends BaseSFTP {
 


### PR DESCRIPTION
This is required when using SFTP subsystem of SSH2 (instead of SFTPStream directly).

Should fix https://github.com/sanketbajoria/ssh2-promise/issues/31