### PR TITLE
fix: catch and re-reject failed promise from sftp()

### DIFF
--- a/src/sftp.ts
+++ b/src/sftp.ts
@@ -11,7 +11,7 @@ var enhanceMethods: any = {"readFileData": "read", "writeFileData": "write", "ge
 class SFTP extends BaseSFTP {
 
     ssh:SSH2Promise;
-    
+
     constructor(ssh:SSH2Promise) {
         super();
         this.ssh = ssh;
@@ -26,7 +26,7 @@ class SFTP extends BaseSFTP {
                     });
                     this.ssh.rawSFTP().then((sftp:any) => {
                         sftp[m].apply(sftp, params);
-                    });
+                    }).catch((err:any) => reject(err));
                 });
             }.bind(this);
         });


### PR DESCRIPTION
I had a hard time with occasional crashs of my app due to rejection in
https://github.com/sanketbajoria/ssh2-promise/blob/master/src/sshConnection.ts#L80

It could happen, if the server closes the connection (for whatever reason) before sftp subsystem is "ready", maybe during completion of handshake. The error from ssh2 is  "No response from server", originated in ssh2\lib\client.js:764:19.

Turns out, the rejected promise is not handled in
https://github.com/sanketbajoria/ssh2-promise/blob/master/src/sftp.ts#L29
so the app crashs with "unhandled promise" exception.

My fix catches the rejected async promise and uses the error for rejecting the current promise.

Now, the error can be handled by the application:
```
sftp.readdir.then().catch()
```
